### PR TITLE
Add Support for Lifeware and Gemstone

### DIFF
--- a/src/XPath-Core/XPathASTTranslatingWritingNodeVisitor.class.st
+++ b/src/XPath-Core/XPathASTTranslatingWritingNodeVisitor.class.st
@@ -882,7 +882,7 @@ XPathASTTranslatingWritingNodeVisitor >> visitNumberLiteral: aNumberLiteral [
 								ifFalse: [self emitNumberLiteral: '0.0']]
 						ifFalse: [
 							"#asString should be OK for all others"
-							self emitNumberLiteral: number asString]]].
+							self emitNumberLiteral: number storeString]]].
 	^ aNumberLiteral.
 ]
 


### PR DESCRIPTION
numbers used for compilation should be using the storing function instead of printing one since it will be used for a block construction