### PR TITLE
Disable caching for tests

### DIFF
--- a/src/XPath-Tests/XPathTest.class.st
+++ b/src/XPath-Tests/XPathTest.class.st
@@ -7,7 +7,8 @@ Class {
 	#instVars : [
 		'document',
 		'namespacedDocument',
-		'textDocument'
+		'textDocument',
+		'oldCompiledExpressionCacheEnabled'
 	],
 	#category : #'XPath-Tests'
 }
@@ -59,18 +60,24 @@ XPathTest >> nodeSetClass [
 
 { #category : #running }
 XPathTest >> setUp [
-	document :=
-		(XMLDOMParser on: XMLParserTest addressBookXML)
+	super setUp.
+	oldCompiledExpressionCacheEnabled := XPath compiledExpressionCacheEnabled.
+	document := (XMLDOMParser on: XMLParserTest addressBookXML)
 			preservesCommentNodes: true;
 			parseDocument.
-	namespacedDocument := 
-		(XMLDOMParser on: XMLParserTest addressBookNamespacePrefixedXML)
+	namespacedDocument := (XMLDOMParser
+			on: XMLParserTest addressBookNamespacePrefixedXML)
 			preservesCommentNodes: true;
 			parseDocument.
-	textDocument :=
-		(XMLDOMParser on: self textDocumentXML)
+	textDocument := (XMLDOMParser on: self textDocumentXML)
 			preservesCommentNodes: true;
-			parseDocument.
+			parseDocument
+]
+
+{ #category : #running }
+XPathTest >> tearDown [
+	XPath compiledExpressionCacheEnabled: oldCompiledExpressionCacheEnabled.
+	super tearDown
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Disable compiled expression cache during test run. If you change the behavior of the core components, you want the test to be accurate